### PR TITLE
feat(docker): add Docker build support for Redis 8 compatibility

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+target/
+Dockerfile*
+.dockerignore
+.git/
+.github/
+*.md
+.gitignore
+docker-compose.yml
+*.so
+test/
+tests/
+benches/
+examples/

--- a/.github/workflows/docker-build-test.yml
+++ b/.github/workflows/docker-build-test.yml
@@ -1,0 +1,74 @@
+name: Test Docker Build
+
+on:
+  workflow_dispatch:  # Manual trigger from GitHub Actions UI
+    inputs:
+      test_tag:
+        description: 'Test tag version (e.g., 0.4.1-redis8.2-bookworm)'
+        required: true
+        default: 'test-build'
+  pull_request:  # Also test on PRs
+    branches:
+      - master
+
+jobs:
+  test-build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Prepare
+        id: prep
+        run: |
+          # For testing, don't push to Docker Hub
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            TEST_TAG="${{ github.event.inputs.test_tag }}"
+            TAGS="redis-cell:latest,redis-cell:stable,redis-cell:${TEST_TAG}"
+          else
+            # For PRs, just use a simple test tag
+            SHORT_SHA=${GITHUB_SHA::8}
+            TAGS="redis-cell:pr-${SHORT_SHA}"
+          fi
+          
+          echo "tags=${TAGS}" >> $GITHUB_OUTPUT
+          echo "Testing build with tags: ${TAGS}"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build (without push)
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile
+          platforms: linux/amd64,linux/arm64
+          pull: true
+          push: false  # Don't push to registry
+          tags: ${{ steps.prep.outputs.tags }}
+          build-args: |
+            BUILDKIT_INLINE_CACHE=1
+
+      - name: Test the built image
+        run: |
+          # Load the image for amd64 only (for testing)
+          docker buildx build --load --platform linux/amd64 -t redis-cell:test .
+          
+          # Start Redis with the module
+          docker run -d --name test-redis redis-cell:test
+          
+          # Wait for Redis to start
+          sleep 5
+          
+          # Test if the module is loaded
+          docker exec test-redis redis-cli MODULE LIST | grep redis-cell
+          
+          # Test the CL.THROTTLE command
+          docker exec test-redis redis-cli CL.THROTTLE test-key 15 30 60 1
+          
+          # Clean up
+          docker stop test-redis
+          docker rm test-redis
+          
+          echo "✅ All tests passed!"

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,49 @@
+name: Docker Image CI
+
+on:
+  release:
+    types:
+      - created
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Prepare
+        id: prep
+        run: |
+          DOCKER_IMAGE=0x8861/redis-cell
+          RELEASE_VERSION=${GITHUB_REF#refs/tags/}
+          
+          # Create tags: latest, stable, and the specific release version
+          TAGS="${DOCKER_IMAGE}:latest,${DOCKER_IMAGE}:stable,${DOCKER_IMAGE}:${RELEASE_VERSION}"
+          
+          echo "tags=${TAGS}" >> $GITHUB_OUTPUT
+          echo "Building and pushing: ${TAGS}"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile
+          platforms: linux/amd64,linux/arm64
+          pull: true
+          push: true
+          cache-from: type=registry,ref=0x8861/redis-cell:stable
+          cache-to: type=inline
+          tags: ${{ steps.prep.outputs.tags }}
+          build-args: |
+            BUILDKIT_INLINE_CACHE=1

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.bk
 redis.conf*
 target
+CLAUDE.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+# Build stage
+FROM redis:8.2-bookworm AS builder
+
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Rust
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+WORKDIR /build
+COPY . .
+
+RUN cargo build --release
+
+# Runtime stage
+FROM redis:8.2-bookworm
+
+# Copy the built module from builder stage to /etc/redis/modules/ to avoid conflicts
+RUN mkdir -p /etc/redis/modules
+COPY --from=builder /build/target/release/libredis_cell.so /etc/redis/modules/
+
+# Expose Redis port
+EXPOSE 6379
+
+# Start Redis with the module loaded
+CMD ["redis-server", "--loadmodule", "/etc/redis/modules/libredis_cell.so"]

--- a/README.md
+++ b/README.md
@@ -24,6 +24,32 @@ per command as seen from a Redis client).
 
 ## Install
 
+### Docker
+
+The easiest way to use redis-cell with the latest stable Redis is via Docker:
+
+```bash
+# Using Docker Hub image (latest version)
+docker run -d -p 6379:6379 0x8861/redis-cell:latest
+
+# Using a specific version (recommended for production)
+docker run -d -p 6379:6379 0x8861/redis-cell:0.4.0-redis8.2-bookworm
+
+# Or with docker-compose
+docker-compose up -d
+```
+
+The Docker image is based on the official Redis stable image and automatically loads the redis-cell module.
+
+**Available Tags:**
+- `latest` - Most recent release
+- `stable` - Same as latest, for production use
+- `<version>-redis<redis-version>-bookworm` - Specific version with explicit Redis version (e.g., `0.4.0-redis8.2-bookworm`)
+
+**Note:** Version tags include the Redis version and OS for full compatibility transparency. This helps ensure you're using the exact environment tested for your production deployment.
+
+### Binary Installation
+
 [Binaries for redis-cell are available for Mac and Linux][releases]. Open
 an issue if there's interest in having binaries for architectures or operating
 systems that are not currently supported.
@@ -37,7 +63,9 @@ $ tar -zxf redis-cell-*.tar.gz
 $ cp libredis_cell.so /path/to/modules/
 ```
 
-**Or**, clone and build the project from source. You'll need to [install
+### Build from Source
+
+Clone and build the project from source. You'll need to [install
 Rust][rust-downloads] to do so (this may be as easy as a `brew install rust` if
 you're on Mac).
 
@@ -49,6 +77,18 @@ $ cp target/release/libredis_cell.dylib /path/to/modules/
 ```
 
 **Note that Rust 1.13.0+ is required.**
+
+### Build with Docker
+
+To build the complete Redis server image with redis-cell module included:
+
+```bash
+$ git clone https://github.com/t-ho/redis-cell.git
+$ cd redis-cell
+$ docker build -t redis-cell .
+```
+
+This creates a Docker image based on the official Redis stable image with the redis-cell module built and loaded automatically. This method ensures compatibility by building in the correct environment.
 
 Run Redis pointing to the newly built module:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '3.8'
+
+services:
+  redis-cell:
+    build: .
+    image: 0x8861/redis-cell:latest
+    container_name: redis-cell
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis-data:/data
+    command: redis-server --loadmodule /usr/local/lib/redis/modules/libredis_cell.so --save 60 1 --loglevel warning
+    restart: unless-stopped
+
+volumes:
+  redis-data:

--- a/test-docker-build.sh
+++ b/test-docker-build.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+set -e
+
+echo "🔨 Testing Docker build locally..."
+
+# Simulate GitHub Actions environment variables
+export GITHUB_REF="refs/tags/0.4.1-redis8.2-bookworm"
+export GITHUB_SHA="abc123def456"
+export DOCKER_IMAGE="0x8861/redis-cell"
+
+# Extract version like the workflow does
+RELEASE_VERSION=${GITHUB_REF#refs/tags/}
+
+# Create tags like the workflow
+TAGS="${DOCKER_IMAGE}:latest,${DOCKER_IMAGE}:stable,${DOCKER_IMAGE}:${RELEASE_VERSION}"
+
+echo "📦 Building with tags: ${TAGS}"
+
+# Build the image locally
+docker build -t redis-cell:test .
+
+echo "🚀 Starting Redis with redis-cell module..."
+# Clean up any existing container
+docker rm -f redis-cell-test 2>/dev/null || true
+
+docker run -d --name redis-cell-test redis-cell:test
+
+# Wait for Redis to start
+sleep 3
+
+# Check if container is running
+if [ "$(docker inspect -f '{{.State.Running}}' redis-cell-test 2>/dev/null)" != "true" ]; then
+    echo "❌ Container failed to start. Logs:"
+    docker logs redis-cell-test
+    exit 1
+fi
+
+echo "✅ Checking if module is loaded..."
+docker exec redis-cell-test redis-cli MODULE LIST | grep -q redis-cell && echo "✓ Module loaded" || (echo "✗ Module not loaded" && exit 1)
+
+echo "🧪 Testing CL.THROTTLE command..."
+RESULT=$(docker exec redis-cell-test redis-cli CL.THROTTLE test-key 15 30 60 1)
+echo "Response: $RESULT"
+
+# Check if response has 5 elements (expected output)
+if [[ $(echo "$RESULT" | wc -l) -eq 5 ]]; then
+    echo "✓ CL.THROTTLE command works!"
+else
+    echo "✗ CL.THROTTLE command failed!"
+    exit 1
+fi
+
+echo "🧹 Cleaning up..."
+docker stop redis-cell-test
+docker rm redis-cell-test
+
+echo "✅ All tests passed! The workflow should work correctly."
+echo ""
+echo "To test the actual GitHub workflow without creating a release:"
+echo "1. Push to a test branch and create a PR to master"
+echo "2. Use the 'Test Docker Build' workflow manually from Actions tab"
+echo "3. Or use 'act' tool to run GitHub Actions locally:"
+echo "   act release --dry-run"


### PR DESCRIPTION
  ## Summary
  Adds complete Docker support for redis-cell to ensure compatibility with Redis 8+. The module now builds in a compatible environment and can be deployed via Docker Hub.

  ## Changes
  - Multi-stage Dockerfile that builds redis-cell in redis:8.2-bookworm environment
  - GitHub Actions workflow to automatically build and push to Docker Hub on release
  - Test workflow for PR validation without pushing to registry
  - Local test script for pre-release verification
  - Docker Compose configuration for easy local deployment
  - Updated documentation with Docker usage instructions

  ## Key Decisions
  - Module installed at `/etc/redis/modules/` to avoid conflicts with Redis Stack modules
  - Release tags follow format: `<version>-redis<redis-version>-bookworm` for clarity
  - Workflow only triggers on release creation (not on push to master)
  - Three Docker tags per release: `latest`, `stable`, and version-specific

  ## Testing
  - Run `./test-docker-build.sh` locally to verify build
  - Test workflow runs automatically on this PR
  - Manual workflow can be triggered from Actions tab
